### PR TITLE
Fix bug preventing display of prefix/suffix prompt

### DIFF
--- a/fuxploider.py
+++ b/fuxploider.py
@@ -245,6 +245,16 @@ if args.manualFormDetection:
                        "Defaulting to empty string - meaning form action will be set to --url parameter.")
     up = UploadForm(args.notRegex, args.trueRegex, s, args.size, postData, args.uploadsPath,
                     args.url, args.formAction, args.inputName)
+    if not args.uploadsPath and args.trueRegex:
+        print("No uploads path provided, code detection can still be done "
+              "using true regex capturing group. "
+              "(Except for templates with a custom codeExecURL)")
+        cont = input("Do you want to use the True Regex for code execution detection ? [Y/n] ")
+        if cont.lower().startswith("y") or cont == "":
+            prefixPattern = input("Prefix capturing group of the true regex with: ")
+            suffixPattern = input("Suffix capturing group of the true regex with: ")
+            up.codeExecUrlPattern = "".join((prefixPattern, "$captGroup$", suffixPattern))
+
 else:
     up = UploadForm(args.notRegex, args.trueRegex, s, args.size, postData, args.uploadsPath)
     up.setup(args.url)


### PR DESCRIPTION
## Issue
When using manual form detection (`-m` flag) with the `--true-regex` parameter but without `--uploads-path`, the code never prompts the user to enter prefix/suffix values for the regex match. This prevents the tool from correctly constructing URLs to test for code execution.

The problem occurs because the prompting code is only in the `setup()` method of the `UploadForm` class, which is bypassed when using manual form detection.

## Fix
This PR adds the missing prompting code to the manual form detection path, ensuring users can specify prefix/suffix values regardless of which detection method they use.

## How to Test
Run Fuxploider with the following command:

```
python fuxploider.py -u "https://example.com" -m -y --input-name "files[]" --form-action "upload?output=json" --true-regex 'filename": "([^"]+)"' --not-regex '"success":\s*false,'
```

You should now be prompted with:
```
No uploads path provided, code detection can still be done using true regex capturing group.
Do you want to use the True Regex for code execution detection ? [Y/n]
```

And after answering 'Y':
```
Prefix capturing group of the true regex with:
Suffix capturing group of the true regex with:
```